### PR TITLE
bcrypt 4.3.0 

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,3 +1,0 @@
-build_env_vars:
-  ANACONDA_ROCKET_ENABLE_PY313 : yes
-

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "bcrypt" %}
-{% set version = "3.2.0" %}
+{% set version = "4.3.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,26 +7,25 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 5b93c1726e50a93a033c36e5ca7fdcd29a5c7395af50a6892f5d9e7c6cfbfb29
+  sha256: 3a3fd2204178b6d2adcf09cb4f6426ffef54762577a7c9b54c159008cb288c18
 
 build:
-  number: 2
-  script: {{ PYTHON }} -m pip install . --no-deps -vv
+  skip: True  # [py<38]
+  number: 0
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vv
 
 requirements:
   build:
     - {{ compiler('c') }}
+    - {{ compiler('rust') }}
   host:
     - python
     - pip
-    - cffi >=1.1
-    - setuptools >=40.8.0
+    - setuptools >=42.0.0
     - wheel
+    - setuptools-rust >=1.7.0
   run:
     - python
-    - pip
-    - cffi >=1.1
-    - six >=1.4.1
 
 test:
   source_files:
@@ -36,6 +35,7 @@ test:
     - bcrypt._bcrypt
   requires:
     - pytest >=3.2.1,!=3.3.0
+    - pip
   commands:
     - pytest tests
     - pip check

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 build:
   skip: True  # [py<38]
   number: 0
-  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vv
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed -vv
 
 requirements:
   build:


### PR DESCRIPTION
bcrypt 4.3.0 

**Destination channel:** Defaults

### Links

- [PKG-7827]
- dev_url:        https://github.com/pyca/bcrypt//tree/4.3.0
- conda_forge:    https://github.com/conda-forge/bcrypt-feedstock
- pypi:           https://pypi.org/project/bcrypt/4.3.0
- pypi inspector: https://inspector.pypi.io/project/bcrypt/4.3.0

### Explanation of changes:

- new version number
  - notably, `bcrypt` v4+ are written in Rust
  - strictly speaking, I think we only need `gcc-libs` but I've left the C compiler in `build`...


[PKG-7827]: https://anaconda.atlassian.net/browse/PKG-7827?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ